### PR TITLE
naming consistency/clarity within src/rail/estimation

### DIFF
--- a/src/rail/estimation/algos/k_nearneigh.py
+++ b/src/rail/estimation/algos/k_nearneigh.py
@@ -39,10 +39,10 @@ def _makepdf(dists, ids, szs, sigma):
     return pdfs
 
 
-class Inform_KNearNeighPDF(CatInformer):
+class KNearNeighInformer(CatInformer):
     """Train a KNN-based estimator
     """
-    name = 'Inform_KNearNeighPDF'
+    name = 'KNearNeighInformer'
     config_options = CatInformer.config_options.copy()
     config_options.update(zmin=SHARED_PARAMS,
                           zmax=SHARED_PARAMS,
@@ -132,10 +132,10 @@ class Inform_KNearNeighPDF(CatInformer):
         self.add_data('model', self.model)
 
 
-class KNearNeighPDF(CatEstimator):
+class KNearNeighEstimator(CatEstimator):
     """KNN-based estimator
     """
-    name = 'KNearNeighPDF'
+    name = 'KNearNeighEstimator'
     config_options = CatEstimator.config_options.copy()
     config_options.update(zmin=SHARED_PARAMS,
                           zmax=SHARED_PARAMS,

--- a/src/rail/estimation/algos/nz_dir.py
+++ b/src/rail/estimation/algos/nz_dir.py
@@ -1,5 +1,5 @@
 """
-Implement simple version of TxPipe NZDir summarizer
+Implement simple version of TxPipe NZDirSummarizer
 """
 
 import numpy as np
@@ -11,7 +11,7 @@ import scipy.spatial
 import pandas as pd
 
 
-class Inform_NZDir(CatInformer):
+class NZDirInformer(CatInformer):
     """Quick implementation of an NZ Estimator that
     creates weights for each input
     object using sklearn's NearestNeighbors.
@@ -30,7 +30,7 @@ class Inform_NZDir(CatInformer):
     bands = ['u', 'g', 'r', 'i', 'z', 'y']
     default_usecols = [f"mag_{band}_lsst" for band in bands]
 
-    name = 'Inform_NZDir'
+    name = 'NZDirInformer'
     config_options = CatInformer.config_options.copy()
     config_options.update(usecols=Param(list, default_usecols, msg="columns from sz_data for Neighor calculation"),
                           n_neigh=Param(int, 10, msg="number of neighbors to use"),
@@ -80,7 +80,7 @@ class Inform_NZDir(CatInformer):
         self.add_data('model', self.model)
 
 
-class NZDir(CatEstimator):
+class NZDirSummarizer(CatEstimator):
     """Quick implementation of a summarizer that creates
     weights for each input object using sklearn's
     NearestNeighbors.  Very basic, we can probably
@@ -104,7 +104,7 @@ class NZDir(CatEstimator):
     bands = ['u', 'g', 'r', 'i', 'z', 'y']
     default_usecols = [f"mag_{band}_lsst" for band in bands]
 
-    name = 'NZDir'
+    name = 'NZDirSummarizer'
     config_options = CatEstimator.config_options.copy()
     config_options.update(zmin=Param(float, 0.0, msg="The minimum redshift of the z grid"),
                           zmax=Param(float, 3.0, msg="The maximum redshift of the z grid"),

--- a/src/rail/estimation/algos/nz_dir.py
+++ b/src/rail/estimation/algos/nz_dir.py
@@ -1,5 +1,5 @@
 """
-Implement simple version of TxPipe NZDirSummarizer
+Implement simple version of TxPipe NZDir
 """
 
 import numpy as np

--- a/src/rail/estimation/algos/sklearn_neurnet.py
+++ b/src/rail/estimation/algos/sklearn_neurnet.py
@@ -58,7 +58,7 @@ def regularize_data(data):
     return regularized_data
 
 
-class Inform_SimpleNN(CatInformer):
+class SklNeurNetInformer(CatInformer):
     """
     Subclass to train a simple point estimate Neural Net photoz
     rather than actually predict PDF, for now just predict point zb
@@ -66,7 +66,7 @@ class Inform_SimpleNN(CatInformer):
     photo-z later.
     """
 
-    name = 'Inform_SimpleNN'
+    name = 'SklNeurNetInformer'
     config_options = CatInformer.config_options.copy()
     config_options.update(zmin=SHARED_PARAMS,
                           zmax=SHARED_PARAMS,
@@ -113,14 +113,14 @@ class Inform_SimpleNN(CatInformer):
         self.add_data('model', self.model)
 
 
-class SimpleNN(CatEstimator):
+class SklNeurNetEstimator(CatEstimator):
     """
     Subclass to implement a simple point estimate Neural Net photoz
     rather than actually predict PDF, for now just predict point zb
     and then put an error of width*(1+zb).  We'll do a "real" NN
     photo-z later.
     """
-    name = 'SimpleNN'
+    name = 'SklNeurNetEstimator'
     config_options = CatEstimator.config_options.copy()
     config_options.update(width=Param(float, 0.05, msg="The ad hoc base width of the PDFs"),
                           ref_band=SHARED_PARAMS,

--- a/src/rail/sklearn/__init__.py
+++ b/src/rail/sklearn/__init__.py
@@ -1,5 +1,5 @@
 from ._version import __version__
 
 from rail.estimation.algos.k_nearneigh import *
-from rail.estimation.algos.sklearn_nn import *
+from rail.estimation.algos.sklearn_neurnet import *
 from rail.estimation.algos.nz_dir import *

--- a/src/rail/sklearn/__init__.py
+++ b/src/rail/sklearn/__init__.py
@@ -2,4 +2,4 @@ from ._version import __version__
 
 from rail.estimation.algos.k_nearneigh import *
 from rail.estimation.algos.sklearn_nn import *
-from rail.estimation.algos.NZDir import *
+from rail.estimation.algos.nz_dir import *

--- a/src/rail/sklearn/__init__.py
+++ b/src/rail/sklearn/__init__.py
@@ -1,5 +1,5 @@
 from ._version import __version__
 
-from rail.estimation.algos.knnpz import *
+from rail.estimation.algos.k_nearneigh import *
 from rail.estimation.algos.sklearn_nn import *
 from rail.estimation.algos.NZDir import *

--- a/tests/sklearn/test_algos.py
+++ b/tests/sklearn/test_algos.py
@@ -4,7 +4,7 @@ import scipy.special
 
 from rail.core.algo_utils import one_algo
 from rail.core.stage import RailStage
-from rail.estimation.algos import knnpz, sklearn_nn
+from rail.estimation.algos import k_nearneigh, sklearn_nn
 
 sci_ver_str = scipy.__version__.split(".")
 
@@ -66,14 +66,14 @@ def test_KNearNeigh():
         nneigh_max=3,
         redshift_column_name="redshift",
         hdf5_groupname="photometry",
-        model="KNearNeighPDF.pkl",
+        model="KNearNeighEstimator.pkl",
     )
-    estim_config_dict = dict(hdf5_groupname="photometry", model="KNearNeighPDF.pkl")
+    estim_config_dict = dict(hdf5_groupname="photometry", model="KNearNeighEstimator.pkl")
 
     # zb_expected = np.array([0.13, 0.14, 0.13, 0.13, 0.11, 0.15, 0.13, 0.14,
     #                         0.11, 0.12])
-    train_algo = knnpz.Inform_KNearNeighPDF
-    pz_algo = knnpz.KNearNeighPDF
+    train_algo = k_nearneigh.KNearNeighInformer
+    pz_algo = k_nearneigh.KNearNeighEstimator
     results, rerun_results, rerun3_results = one_algo(
         "KNN", train_algo, pz_algo, train_config_dict, estim_config_dict
     )

--- a/tests/sklearn/test_algos.py
+++ b/tests/sklearn/test_algos.py
@@ -4,7 +4,7 @@ import scipy.special
 
 from rail.core.algo_utils import one_algo
 from rail.core.stage import RailStage
-from rail.estimation.algos import k_nearneigh, sklearn_nn
+from rail.estimation.algos import k_nearneigh, sklearn_neurnet
 
 sci_ver_str = scipy.__version__.split(".")
 
@@ -24,8 +24,8 @@ def test_simple_nn():
     }
     estim_config_dict = {"hdf5_groupname": "photometry", "model": "model.tmp"}
     # zb_expected = np.array([0.152, 0.135, 0.109, 0.158, 0.113, 0.176, 0.13 , 0.15 , 0.119, 0.133])
-    train_algo = sklearn_nn.Inform_SimpleNN
-    pz_algo = sklearn_nn.SimpleNN
+    train_algo = sklearn_neurnet.SklNeurNetInformer
+    pz_algo = sklearn_neurnet.SklNeurNetEstimator
     results, rerun_results, rerun3_results = one_algo(
         "SimpleNN", train_algo, pz_algo, train_config_dict, estim_config_dict
     )
@@ -84,6 +84,6 @@ def test_KNearNeigh():
 def test_catch_bad_bands():
     params = dict(bands="u,g,r,i,z,y")
     with pytest.raises(ValueError):
-        sklearn_nn.Inform_SimpleNN.make_stage(hdf5_groupname="", **params)
+        sklearn_neurnet.SklNeurNetInformer.make_stage(hdf5_groupname="", **params)
     with pytest.raises(ValueError):
-        sklearn_nn.SimpleNN.make_stage(hdf5_groupname="", **params)
+        sklearn_neurnet.SklNeurNetEstimator.make_stage(hdf5_groupname="", **params)


### PR DESCRIPTION
## Change Description

This PR (and other concurrent PRs in the other repos) include renamings of modules and stages within `src/rail/estimation` for consistency and transparency to users as outlined in LSSTDESC/rail#37. (Expect a few more PRs to address the smaller set of necessary consistency/clarity changes outside `src/rail/estimation` using the same branch.) 

- [x] My PR includes a link to the issue that I am addressing

I request that multiple reviewers please do not hesitate to suggest changes as needed! The goals are consistency, clarity, and longevity, so if something looks unclear, inconsistent, or insufficiently flexible to accommodate future development, now is the time to make adjustments.

## Solution Description

The following changes were made across all the rail repos, along with updates to the contributing documentation (which should be propagated to the rail python project template so prompts regarding naming are included in future PR checklists).

```
files:
  delightPZ.py --> delight_hybrid.py
  GPz.py --> _gpz_util.py
  knnpz.py --> k_nearneigh.py
  naiveStack.py --> naive_stack.py
  NZDir.py --> nz_dir.py
  pointEstimateHist.py --> point_est_hist.py
  pzflow.py --> pzflow_nf.py
  randomPZ.py --> random_gauss.py
  simpleSOM.py --> minisom_som.py
  sklearn_nn.py --> skl_neurnet.py
  somocluSOM.py --> somoclu_som.py
  trainZ.py --> train_z.py
  varInference.py --> var_inf.py
classes:
  Inform_BPZ_lite --> BPZliteInformer
  BPZ_lite --> BPZliteEstimator
  Inform_CMNNPDF --> CMNNInformer
  CMNNPDF --> CMNNEstimator
  Inform_DelightPZ --> DelightInformer
  delightPZ --> DelightEstimator  
  Inform_GPz_v1 --> GPzInformer
  GPz_v1 --> GPzEstimator
  Inform_FZBoost --> FlexZBoostInformer
  FZBoost --> FlexZBoostEstimator
  Inform_KNearNeighPDF --> KNearNeighInformer
  KNearNeighPDF --> KNearNeighEstimator
  NaiveStack --> NaiveStackSummarizer
  NZDir --> NZDirSummarizer  
  Inform_NZDir --> NZDirInformer
  PointEstimateHist --> PointEstHistSummarizer
  Inform_PZFlowPDF --> PZFlowInformer
  PZFlowPDF --> PZFlowEstimator
  RandomPZ --> RandomGaussEstimator
  Inform_SimpleNN --> SklNeurNetInformer
  SimpleNN --> SklNeurNetEstimator
  Inform_SimpleSOMSummarizer --> MiniSOMInformer
  SimpleSOMSummarizer --> MiniSOMSummarizer
  Inform_somocluSOMSummarizer --> SOMocluInformer
  somocluSOMSummarizer --> SOMocluSummarizer
  Inform_trainZ --> TrainZInformer
  TrainZ --> TrainZEstimator
  VarInferenceStack --> VarInfStackSummarizer   
```

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

### Bug Fix Checklist
- [X] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

Given that we are still pre-v1, I have not explicitly included backward compatibility, but a block of `import X as Y` can be constructed from the above list of changes.

### Other Change Checklist
- [X] I have updated the tutorial to highlight my new feature (if appropriate)
- [x] I have updated unit/End-to-End (E2E) test cases to cover any changes

I fixed some instances of outdated descriptions in the demo notebooks, but others require more substantial editing, e.g. when they describe code that has long since been removed from the demo in question or aspects of the API that have significantly changed since the descriptions were written. The demos require a thorough review before v1 that's out of scope for this series of PRs.