### PR TITLE
add TEENY to distances

### DIFF
--- a/src/rail/estimation/algos/k_nearneigh.py
+++ b/src/rail/estimation/algos/k_nearneigh.py
@@ -18,6 +18,8 @@ import pandas as pd
 import qp
 
 
+TEENY = 1.e-15
+
 
 def _computecolordata(df, ref_column_name, column_names):
     newdict = {}
@@ -116,6 +118,8 @@ class KNearNeighInformer(CatInformer):
         for sig in siggrid:
             for nn in range(self.config.nneigh_min, self.config.nneigh_max + 1):
                 dists, idxs = tmpmodel.query(val_data, k=nn)
+                # add a small small number to guard against NaN when obj of same color exists in spec file
+                dists += TEENY
                 ens = _makepdf(dists, idxs, train_sz, sig)
                 cdelossobj = CDELoss(ens, self.zgrid, val_sz)
                 cdeloss = cdelossobj.evaluate().statistic
@@ -161,7 +165,7 @@ class KNearNeighEstimator(CatEstimator):
 
     def open_model(self, **kwargs):
         CatEstimator.open_model(self, **kwargs)
-        if self.model is None:  #pragma: no cover
+        if self.model is None:   # pragma: no cover
             return
         self.sigma = self.model['bestsig']
         self.numneigh = self.model['nneigh']


### PR DESCRIPTION
This PR just adds a TEENY number to the distances in k_nearneigh, as when you have an exact match to a spectroscopic point (e.g. if you accidentally run with the same training and test data) you get a distance = 0 and because we have a weight = 1/dist factor you can get infs and/or NaNs.  Adding TEENY to the distances makes sure we do not have a divide by zero.