### PR TITLE
Fixing the number of chunks needed

### DIFF
--- a/src/rail/estimation/algos/nz_dir.py
+++ b/src/rail/estimation/algos/nz_dir.py
@@ -158,11 +158,10 @@ class NZDirSummarizer(CatEstimator):
         first = True
         self._initialize_run()
         self._output_handle = None
-        total_chunks = int(np.ceil(self._input_length/self.config.chunk_size))
         for s, e, test_data in iterator:
             print(f"Process {self.rank} running estimator on chunk {s} - {e}")
-
-            total_chunks = int(np.ceil(self._input_length/self.config.chunk_size))
+            if first:
+                total_chunks = int(np.ceil(self._input_length/(e-s)))
             chunk_number = s//self.config.chunk_size
             self._process_chunk(first, total_chunks, chunk_number, test_data, bootstrap_matrix)
             first = False


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
When `NZDir` was trying to obtain the number of chunks needed to perform the computation as `ceil(input_lenght/chunk_size)`. This is wrong when the iterator is executed in Jupyter  because in that case it only uses one big chunk.

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
