### PR TITLE
Update for ceci version 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "pz_rail_base @ git+https://github.com/LSSTDESC/rail_base@ceci2",
+    "pz-rail-base>=1.0.3",
     "scikit-learn",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "pz-rail-base",
+    "ceci2 @ https://github.com/LSSTDESC/rail_base",
     "scikit-learn",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "ceci2 @ https://github.com/LSSTDESC/rail_base",
+    "ceci2 @ git+https://github.com/LSSTDESC/rail_base",
     "scikit-learn",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "ceci2 @ git+https://github.com/LSSTDESC/rail_base",
+    "pz_rail_base @ git+https://github.com/LSSTDESC/rail_base@ceci2",
     "scikit-learn",
 ]
 

--- a/src/rail/estimation/algos/k_nearneigh.py
+++ b/src/rail/estimation/algos/k_nearneigh.py
@@ -68,7 +68,7 @@ class KNearNeighInformer(CatInformer):
     def __init__(self, args, **kwargs):
         """ Constructor
         Do CatInformer specific initialization, then check on bands """
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
 
         usecols = self.config.bands.copy()
         usecols.append(self.config.redshift_col)
@@ -158,7 +158,7 @@ class KNearNeighEstimator(CatEstimator):
         self.model = None
         self.trainszs = None
         self.zgrid = None
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         usecols = self.config.bands.copy()
         usecols.append(self.config.redshift_col)
         self.usecols = usecols

--- a/src/rail/estimation/algos/k_nearneigh.py
+++ b/src/rail/estimation/algos/k_nearneigh.py
@@ -65,10 +65,10 @@ class KNearNeighInformer(CatInformer):
                           nneigh_min=Param(int, 3, msg="int, min number of near neighbors to use for PDF fit"),
                           nneigh_max=Param(int, 7, msg="int, max number of near neighbors to use ofr PDF fit"))
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """ Constructor
         Do CatInformer specific initialization, then check on bands """
-        CatInformer.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
 
         usecols = self.config.bands.copy()
         usecols.append(self.config.redshift_col)
@@ -150,7 +150,7 @@ class KNearNeighEstimator(CatEstimator):
                           mag_limits=SHARED_PARAMS,
                           redshift_col=SHARED_PARAMS)
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """ Constructor:
         Do Estimator specific initialization """
         self.sigma = None
@@ -158,7 +158,7 @@ class KNearNeighEstimator(CatEstimator):
         self.model = None
         self.trainszs = None
         self.zgrid = None
-        CatEstimator.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         usecols = self.config.bands.copy()
         usecols.append(self.config.redshift_col)
         self.usecols = usecols

--- a/src/rail/estimation/algos/nz_dir.py
+++ b/src/rail/estimation/algos/nz_dir.py
@@ -121,7 +121,7 @@ class NZDirSummarizer(CatEstimator):
         self.szweights = None
         self.sz_mag_data = None
         self.bincents = None
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
 
     def open_model(self, **kwargs):
         CatEstimator.open_model(self, **kwargs)

--- a/src/rail/estimation/algos/nz_dir.py
+++ b/src/rail/estimation/algos/nz_dir.py
@@ -41,11 +41,6 @@ class NZDirInformer(CatInformer):
                           distance_delta=Param(float, 1.e-6, msg="padding for distance calculation"),
                           hdf5_groupname=Param(str, "photometry", msg="name of hdf5 group for data, if None, then set to ''"))
 
-    def __init__(self, args, comm=None):
-        """ Constructor:
-        Do Informer specific initialization """
-        CatInformer.__init__(self, args, comm=comm)
-
     def run(self):
         from sklearn.neighbors import NearestNeighbors
 
@@ -118,7 +113,7 @@ class NZDirSummarizer(CatEstimator):
     outputs = [('output', QPHandle),
                ('single_NZ', QPHandle)]
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         self.zgrid = None
         self.model = None
         self.distances = None
@@ -126,7 +121,7 @@ class NZDirSummarizer(CatEstimator):
         self.szweights = None
         self.sz_mag_data = None
         self.bincents = None
-        CatEstimator.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
 
     def open_model(self, **kwargs):
         CatEstimator.open_model(self, **kwargs)

--- a/src/rail/estimation/algos/random_forest.py
+++ b/src/rail/estimation/algos/random_forest.py
@@ -38,9 +38,6 @@ class RandomForestInformer(CatInformer):
         random_seed=Param(int, msg="random seed"),
         no_assign=Param(int, -99, msg="Value for no assignment flag"),)
     outputs = [('model', ModelHandle)]
-    
-    def __init__(self, args, comm=None):
-        CatInformer.__init__(self, args, comm=comm)
         
     def run(self):
         # Load the training data
@@ -107,10 +104,6 @@ class RandomForestClassifier(CatClassifier):
         class_bands=Param(tuple, ["r","i","z"], msg="Which bands to use for classification"),
         bands=Param(dict, {"r":"mag_r_lsst", "i":"mag_i_lsst", "z":"mag_z_lsst"}, msg="column names for the the bands"),)
     outputs = [('output', Hdf5Handle)]
-    
-    def __init__(self, args, comm=None):
-        CatClassifier.__init__(self, args, comm=comm)
-            
             
     def open_model(self, **kwargs):
         CatClassifier.open_model(self, **kwargs)

--- a/src/rail/estimation/algos/sklearn_neurnet.py
+++ b/src/rail/estimation/algos/sklearn_neurnet.py
@@ -85,10 +85,10 @@ class SklNeurNetInformer(CatInformer):
                                           "not optimally)"))
 
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """ Constructor:
         Do CatInformer specific initialization """
-        CatInformer.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         if self.config.ref_band not in self.config.bands:
             raise ValueError("ref_band not present in bands list! ")
 
@@ -127,10 +127,10 @@ class SklNeurNetEstimator(CatEstimator):
                           nondetect_val=SHARED_PARAMS,
                           bands=SHARED_PARAMS)
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """ Constructor:
         Do CatEstimator specific initialization """
-        CatEstimator.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         if self.config.ref_band not in self.config.bands:
             raise ValueError("ref_band is not in list of bands!")
 

--- a/src/rail/estimation/algos/sklearn_neurnet.py
+++ b/src/rail/estimation/algos/sklearn_neurnet.py
@@ -88,7 +88,7 @@ class SklNeurNetInformer(CatInformer):
     def __init__(self, args, **kwargs):
         """ Constructor:
         Do CatInformer specific initialization """
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         if self.config.ref_band not in self.config.bands:
             raise ValueError("ref_band not present in bands list! ")
 
@@ -130,7 +130,7 @@ class SklNeurNetEstimator(CatEstimator):
     def __init__(self, args, **kwargs):
         """ Constructor:
         Do CatEstimator specific initialization """
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         if self.config.ref_band not in self.config.bands:
             raise ValueError("ref_band is not in list of bands!")
 


### PR DESCRIPTION
This PR updates the constructors of all stage subclasses to work with ceci version 2, in which aliases are specified in the constructor. A similar PR has been opened for each RAIL repo.

The main change is to the the constructors to accept any keywords with **kwargs and pass them to the parent class.

I have also removed any constructors which did not do anything except call the parent class constructor. Since this happens automatically if you omit the constructor, these were redundant.

Finally, in constructors I have changed I have removed hard-coded parent classes in favour of the python3 recommended super() function. If the parent class are changed in the future the constructor will still work.