### PR TITLE
add 'only_colors' option to KNearNeigh #20

### DIFF
--- a/tests/sklearn/test_algos.py
+++ b/tests/sklearn/test_algos.py
@@ -15,6 +15,7 @@ sci_ver_str = scipy.__version__.split(".")
 DS = RailStage.data_store
 DS.__class__.allow_overwrite = True
 
+
 def test_simple_nn():
     train_config_dict = {
         "width": 0.025,
@@ -34,7 +35,6 @@ def test_simple_nn():
     )
     # assert np.isclose(results.ancil['zmode'], zb_expected).all()
     assert np.isclose(results.ancil["zmode"], rerun_results.ancil["zmode"]).all()
-
 
 
 @pytest.mark.skipif(
@@ -83,6 +83,7 @@ def test_KNearNeigh():
     # assert np.isclose(results.ancil['zmode'], zb_expected).all()
     assert np.isclose(results.ancil["zmode"], rerun_results.ancil["zmode"]).all()
 
+
 # test for k=1 when data point has same value, used to cause errors because of
 # a divide by zero, should be fixed now but add a test
 def test_same_data_knn():
@@ -103,21 +104,65 @@ def test_same_data_knn():
     assert ~(np.isnan(modes).all())
     os.remove(pz.get_output(pz.get_aliased_tag('output'), final_name=True))
 
-    
+
+def test_KNearNeigh_justcol():
+    def_bands = ["u", "g", "r", "i", "z", "y"]
+    refcols = [f"mag_{band}_lsst" for band in def_bands]
+    def_maglims = dict(
+        mag_u_lsst=27.79,
+        mag_g_lsst=29.04,
+        mag_r_lsst=29.06,
+        mag_i_lsst=28.62,
+        mag_z_lsst=27.98,
+        mag_y_lsst=27.05,
+    )
+    train_config_dict = dict(
+        zmin=0.0,
+        zmax=3.0,
+        nzbins=301,
+        trainfrac=0.75,
+        random_seed=87,
+        ref_column_name="mag_i_lsst",
+        column_names=refcols,
+        mag_limits=def_maglims,
+        sigma_grid_min=0.02,
+        sigma_grid_max=0.03,
+        ngrid_sigma=2,
+        leaf_size=2,
+        nneigh_min=2,
+        nneigh_max=3,
+        redshift_column_name="redshift",
+        hdf5_groupname="photometry",
+        model="KNearNeighEstimator_justcols.pkl",
+        only_colors=True,
+    )
+    estim_config_dict = dict(hdf5_groupname="photometry", model="KNearNeighEstimator_justcols.pkl", only_colors=True)
+
+    # zb_expected = np.array([0.13, 0.14, 0.13, 0.13, 0.11, 0.15, 0.13, 0.14,
+    #                         0.11, 0.12])
+    train_algo = k_nearneigh.KNearNeighInformer
+    pz_algo = k_nearneigh.KNearNeighEstimator
+    results, rerun_results, rerun3_results = one_algo(
+        "KNNjustcol", train_algo, pz_algo, train_config_dict, estim_config_dict
+    )
+    # assert np.isclose(results.ancil['zmode'], zb_expected).all()
+    assert np.isclose(results.ancil["zmode"], rerun_results.ancil["zmode"]).all()
+
+
 def test_catch_bad_bands():
     params = dict(bands="u,g,r,i,z,y")
     with pytest.raises(ValueError):
         sklearn_neurnet.SklNeurNetInformer.make_stage(hdf5_groupname="", **params)
     with pytest.raises(ValueError):
         sklearn_neurnet.SklNeurNetEstimator.make_stage(hdf5_groupname="", **params)
-        
+
 
 def test_randomForestClassifier():
-    class_bands = [ "r","i","z"]
+    class_bands = ["r", "i", "z"]
     bands = {"r": "mag_r_lsst", "i": "mag_i_lsst", "z": "mag_z_lsst"}
-    bin_edges=[0,0.2,0.5]
-    
-    train_config_dict=dict(
+    bin_edges = [0, 0.2, 0.5]
+
+    train_config_dict = dict(
         class_bands=class_bands,
         bands=bands,
         redshift_col="redshift",
@@ -126,9 +171,9 @@ def test_randomForestClassifier():
         hdf5_groupname="photometry",
         model="model.tmp",
     )
-    
-    estim_config_dict=dict(hdf5_groupname="photometry", model="model.tmp", id_name="")
-    
+
+    estim_config_dict = dict(hdf5_groupname="photometry", model="model.tmp", id_name="")
+
     train_algo = random_forest.RandomForestInformer
     tomo_algo = random_forest.RandomForestClassifier
     results, rerun_results, rerun3_results = one_algo(
@@ -136,15 +181,15 @@ def test_randomForestClassifier():
         is_classifier=True,
     )
     assert np.isclose(results["data"]["class_id"], rerun_results["data"]["class_id"]).all()
-    assert len(results["data"]["class_id"])==len(results["data"]["row_index"])
+    assert len(results["data"]["class_id"]) == len(results["data"]["row_index"])
 
 
 def test_randomForestClassifier_id():
-    class_bands = [ "r","i","z"]
+    class_bands = ["r", "i", "z"]
     bands = {"r": "mag_r_lsst", "i": "mag_i_lsst", "z": "mag_z_lsst"}
-    bin_edges=[0,0.2,0.5]
-    
-    train_config_dict=dict(
+    bin_edges = [0, 0.2, 0.5]
+
+    train_config_dict = dict(
         class_bands=class_bands,
         bands=bands,
         redshift_col="redshift",
@@ -153,32 +198,32 @@ def test_randomForestClassifier_id():
         hdf5_groupname="photometry",
         model="model.tmp",
     )
-    estim_config_dict=dict(hdf5_groupname="photometry", model="model.tmp", id_name="id")
-    
+    estim_config_dict = dict(hdf5_groupname="photometry", model="model.tmp", id_name="id")
+
     train_algo = random_forest.RandomForestInformer
     tomo_algo = random_forest.RandomForestClassifier
-    
+
     traindata = os.path.join(RAILDIR, 'rail/examples_data/testdata/training_100gal.hdf5')
     validdata = os.path.join(RAILDIR, 'rail/examples_data/testdata/validation_10gal.hdf5')
-    
+
     DS = RailStage.data_store
     DS.__class__.allow_overwrite = True
     DS.clear()
     training_data = DS.read_file('training_data', TableHandle, traindata)
     validation_data = DS.read_file('validation_data', TableHandle, validdata)
-    
+
     train_pz = train_algo.make_stage(**train_config_dict)
     train_pz.inform(training_data)
     pz = tomo_algo.make_stage(name="randomForestClassifier", **estim_config_dict)
     estim = pz.classify(training_data)
-    results=estim.data
-    
+    results = estim.data
+
     os.remove(pz.get_output(pz.get_aliased_tag('output'), final_name=True))
     model_file = estim_config_dict.get('model', 'None')
     if model_file != 'None':
         try:
             os.remove(model_file)
-        except FileNotFoundError:  #pragma: no cover
+        except FileNotFoundError:  # pragma: no cover
             pass
-    
-    assert len(results["data"]["class_id"])==len(results["data"]["id"])
+
+    assert len(results["data"]["class_id"]) == len(results["data"]["id"])


### PR DESCRIPTION
Addresses issue #20 by adding an `only_colors` config param to KNearnNeigh, if set to True this does not use the reference band magnitude in the nearest neighbor calculation.  I also added an explicit `np.float32` cast to the nondetect replacements, as I noticed a ton of deprecation warnings from pandas when running the tests where it was not realizing that 27.79 was a float32 and threatening to throw an exception on a future pandas version. 
Also, some minor linting fixes for whitespace and such in the test_algos.py

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
