### PR TITLE
The total number of chunks was not computed properly 

### DIFF
--- a/src/rail/estimation/algos/nz_dir.py
+++ b/src/rail/estimation/algos/nz_dir.py
@@ -156,7 +156,7 @@ class NZDirSummarizer(CatEstimator):
         for s, e, test_data in iterator:
             print(f"Process {self.rank} running estimator on chunk {s} - {e}")
             if first:
-                total_chunks = int(np.ceil(self._input_length/(e-s)))
+                total_chunks = int(np.ceil(self._input_length/self.config.chunk_size))
             chunk_number = s//self.config.chunk_size
             self._process_chunk(first, total_chunks, chunk_number, test_data, bootstrap_matrix)
             first = False


### PR DESCRIPTION
When the data lenght is smaller than n_process*chunk_size, the last process was not computing properly the chunk_size.

## Problem & Solution Description (including issue #)


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
