### PR TITLE
move only_colors to model and remove from estimate #20

### DIFF
--- a/tests/sklearn/test_algos.py
+++ b/tests/sklearn/test_algos.py
@@ -136,7 +136,7 @@ def test_KNearNeigh_justcol():
         model="KNearNeighEstimator_justcols.pkl",
         only_colors=True,
     )
-    estim_config_dict = dict(hdf5_groupname="photometry", model="KNearNeighEstimator_justcols.pkl", only_colors=True)
+    estim_config_dict = dict(hdf5_groupname="photometry", model="KNearNeighEstimator_justcols.pkl")
 
     # zb_expected = np.array([0.13, 0.14, 0.13, 0.13, 0.11, 0.15, 0.13, 0.14,
     #                         0.11, 0.12])


### PR DESCRIPTION
Currently only_colors is an config option in both inform and estimate, but if the model is optimized for one of the two boolean values, 1) you probably don't want to use the other option, as it wasn't optimized for and 2) it throws an error and won't work as set up anyway.  So, instead, this PR lets the user set the option in the inform stage and stores it in the model so it doesn't need to be set in estimate.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
