### PR TITLE
allow for older models that don't have only_colors option

### DIFF
--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -28,7 +28,7 @@ jobs:
         sudo apt-get update
         python -m pip install --upgrade pip
         pip install wheel numpy
-	pip install setuptools
+        pip install setuptools
         pip install .
         pip install .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v3
@@ -28,6 +28,7 @@ jobs:
         sudo apt-get update
         python -m pip install --upgrade pip
         pip install wheel numpy
+	pip install setuptools
         pip install .
         pip install .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pz-rail-sklearn"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {file = "LICENSE"}
 readme = "README.md"
 authors = [
@@ -16,7 +16,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "pz-rail-base>=1.0.3",
+    "pz-rail-base>=1.1.4",
     "scikit-learn",
 ]
 

--- a/src/rail/estimation/algos/k_nearneigh.py
+++ b/src/rail/estimation/algos/k_nearneigh.py
@@ -178,7 +178,7 @@ class KNearNeighEstimator(CatEstimator):
         self.numneigh = self.model['nneigh']
         self.kdtree = self.model['kdtree']
         self.trainszs = self.model['truezs']
-        self.only_colors = self.model['only_colors']
+        self.only_colors = self.model.get('only_colors', True)
 
     def _process_chunk(self, start, end, data, first):
         """


### PR DESCRIPTION
## Problem & Solution Description (including issue #)


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
