### PR TITLE
rename params for sklearn

### DIFF
--- a/src/rail/estimation/algos/k_nearneigh.py
+++ b/src/rail/estimation/algos/k_nearneigh.py
@@ -56,7 +56,7 @@ class KNearNeighInformer(CatInformer):
         ref_band=SHARED_PARAMS,
         redshift_col=SHARED_PARAMS,
         hdf5_groupname=SHARED_PARAMS,
-        trainfrac=Param(
+        train_frac=Param(
             float,
             0.75,
             msg="fraction of training data used to make tree, rest used to set best sigma",
@@ -121,7 +121,7 @@ class KNearNeighInformer(CatInformer):
         nobs = colordata.shape[0]
         rng = np.random.default_rng(seed=self.config.seed)
         perm = rng.permutation(nobs)
-        ntrain = round(nobs * self.config.trainfrac)
+        ntrain = round(nobs * self.config.train_frac)
         xtrain_data = colordata[perm[:ntrain]]
         train_data = copy.deepcopy(xtrain_data)
         val_data = colordata[perm[ntrain:]]

--- a/src/rail/estimation/algos/nz_dir.py
+++ b/src/rail/estimation/algos/nz_dir.py
@@ -7,6 +7,7 @@ import pandas as pd
 import qp
 import scipy.spatial
 from ceci.config import StageParameter as Param
+from rail.core.common_params import SHARED_PARAMS
 from rail.core.data import QPHandle
 from rail.estimation.estimator import CatEstimator, CatInformer
 
@@ -37,7 +38,7 @@ class NZDirInformer(CatInformer):
         n_neigh=Param(int, 10, msg="number of neighbors to use"),
         kalgo=Param(str, "kd_tree", msg="Neighbor algorithm to use"),
         kmetric=Param(str, "euclidean", msg="Knn metric to use"),
-        szname=Param(str, "redshift", msg="name of specz column in sz_data"),
+        sz_name=Param(str, "redshift", msg="name of specz column in sz_data"),
         szweightcol=Param(str, "", msg="name of sz weight column"),
         distance_delta=Param(float, 1.0e-6, msg="padding for distance calculation"),
         hdf5_groupname=Param(
@@ -67,7 +68,7 @@ class NZDirInformer(CatInformer):
             )
         sz_mag_data = np.array([sz_data[band] for band in self.config.usecols]).T
         sz_mag_data[~np.isfinite(sz_mag_data)] = 40.0
-        szvec = np.array(sz_data[self.config.szname])
+        szvec = np.array(sz_data[self.config.sz_name])
         neighbors = NearestNeighbors(
             n_neighbors=self.config["n_neigh"],
             algorithm=self.config["kalgo"],
@@ -102,12 +103,12 @@ class NZDirSummarizer(CatEstimator):
     interactive_function = "nz_dir_summarizer"
     config_options = CatEstimator.config_options.copy()
     config_options.update(
-        zmin=Param(float, 0.0, msg="The minimum redshift of the z grid"),
-        zmax=Param(float, 3.0, msg="The maximum redshift of the z grid"),
-        nzbins=Param(int, 301, msg="The number of gridpoints in the z grid"),
+        zmin=SHARED_PARAMS,
+        zmax=SHARED_PARAMS,
+        nzbins=SHARED_PARAMS,
         seed=Param(int, 87, msg="random seed"),
         usecols=Param(
-            list, default_usecols, msg="columns from sz_date for Neighbor calculation"
+            list, default_usecols, msg="columns from sz_data for Neighbor calculation"
         ),
         leafsize=Param(int, 40, msg="leaf size for testdata KDTree"),
         hdf5_groupname=Param(
@@ -116,7 +117,7 @@ class NZDirSummarizer(CatEstimator):
             msg="name of hdf5 group for data, if None, then set to ''",
         ),
         phot_weightcol=Param(str, "", msg="name of photometry weight, if present"),
-        nsamples=Param(int, 20, msg="number of bootstrap samples to generate"),
+        n_samples=Param(int, 20, msg="number of bootstrap samples to generate"),
     )
     outputs = [("output", QPHandle), ("single_NZ", QPHandle)]
 
@@ -149,7 +150,7 @@ class NZDirSummarizer(CatEstimator):
         # Creating de indices for the bootstrap sampling, and broadcasting to the other process
         # if we are running in parallel
         ngal = len(self.szweights)
-        nsamp = self.config.nsamples
+        nsamp = self.config.n_samples
         if self.rank == 0:
             bootstrap_matrix = rng.integers(low=0, high=ngal, size=(ngal, nsamp))
         else:  # pragma: no cover
@@ -240,7 +241,7 @@ class NZDirSummarizer(CatEstimator):
         # The way things are set up, it is easier and faster to bootstrap the spec-z gals
         # and weights, but if we wanted to be more like the other bootstraps we should really
         # bootstrap the photometric data and re-run the ball tree query N times.
-        nsamp = self.config.nsamples
+        nsamp = self.config.n_samples
         hist_vals = np.empty((nsamp, self.config.nzbins))
         for i in range(nsamp):
             bootstrap_indices = bootstrap_matrix[:, i]
@@ -323,7 +324,7 @@ class NZDirSummarizer(CatEstimator):
 
         tab_samples = sample_ens_spread.build_tables()
 
-        nsamp = self.config.nsamples
+        nsamp = self.config.n_samples
         hist_samples = np.zeros((nsamp, self.config.nzbins))
         normalization = tab_samples["ancil"]["normalization"]
         hist_samples_spread = tab_samples["data"]["pdfs"] * normalization[:, None]

--- a/src/rail/estimation/algos/random_forest.py
+++ b/src/rail/estimation/algos/random_forest.py
@@ -37,14 +37,14 @@ class RandomForestInformer(CatInformer):
         class_bands=Param(
             list, ["r", "i", "z"], msg="Which bands to use for classification"
         ),
-        bands=Param(
+        band_map=Param(
             dict,
             {"r": "mag_r_lsst", "i": "mag_i_lsst", "z": "mag_z_lsst"},
             msg="column names for the the bands",
         ),
         redshift_col=Param(str, "sz", msg="Redshift column names"),
         bin_edges=Param(list, [0, 0.5, 1.0], msg="Binning for training data"),
-        random_seed=Param(int, msg="random seed"),
+        seed=Param(int, msg="random seed"),
         no_assign=Param(int, -99, msg="Value for no assignment flag"),
     )
     outputs = [("model", ModelHandle)]
@@ -58,7 +58,7 @@ class RandomForestInformer(CatInformer):
 
         # Pull out the appropriate columns and combinations of the data
         print(
-            f"Using these bands to train the tomography selector: {self.config.bands}"
+            f"Using these bands to train the tomography selector: {self.config.band_map}"
         )
 
         # Generate the training data that we will use
@@ -66,13 +66,13 @@ class RandomForestInformer(CatInformer):
         features = []
         training_data = []
         for b1 in self.config.class_bands[:]:
-            b1_cat = self.config.bands[b1]
+            b1_cat = self.config.band_map[b1]
             # First we use the magnitudes themselves
             features.append(b1)
             training_data.append(training_data_table[b1_cat])
             # We also use the colours as training data, even the redundant ones
             for b2 in self.config.class_bands[:]:
-                b2_cat = self.config.bands[b2]
+                b2_cat = self.config.band_map[b2]
                 if b1 < b2:
                     features.append(f"{b1}-{b2}")
                     training_data.append(
@@ -98,7 +98,7 @@ class RandomForestInformer(CatInformer):
             max_depth=10,
             max_features=None,
             n_estimators=20,
-            random_state=self.config.random_seed,
+            random_state=self.config.seed,
         )
         skl_classifier.fit(training_data, training_bin)
 
@@ -123,7 +123,7 @@ class RandomForestClassifier(CatClassifier):
         class_bands=Param(
             list, ["r", "i", "z"], msg="Which bands to use for classification"
         ),
-        bands=Param(
+        band_map=Param(
             dict,
             {"r": "mag_r_lsst", "i": "mag_i_lsst", "z": "mag_z_lsst"},
             msg="column names for the the bands",
@@ -150,13 +150,13 @@ class RandomForestClassifier(CatClassifier):
         for f in self.features:
             # may be a single band
             if len(f) == 1:
-                f_cat = self.config.bands[f]
+                f_cat = self.config.band_map[f]
                 col = test_data[f_cat]
             # or a colour
             else:
                 b1, b2 = f.split("-")
-                b1_cat = self.config.bands[b1]
-                b2_cat = self.config.bands[b2]
+                b1_cat = self.config.band_map[b1]
+                b2_cat = self.config.band_map[b2]
                 col = test_data[b1_cat] - test_data[b2_cat]
             if np.all(~np.isfinite(col)):
                 # entire column is NaN.  Hopefully this will get deselected elsewhere
@@ -176,7 +176,7 @@ class RandomForestClassifier(CatClassifier):
             obj_id = test_data[self.config.id_name]
         elif self.config.id_name == "":
             # ID set to row index
-            b = self.config.bands[self.config.class_bands[0]]
+            b = self.config.band_map[self.config.class_bands[0]]
             obj_id = np.arange(len(test_data[b]))
             self.config.id_name = "row_index"
 

--- a/tests/sklearn/test_algos.py
+++ b/tests/sklearn/test_algos.py
@@ -53,8 +53,8 @@ def test_KNearNeigh():
         zmin=0.0,
         zmax=3.0,
         nzbins=301,
-        trainfrac=0.75,
-        random_seed=87,
+        train_frac=0.75,
+        seed=87,
         ref_column_name="mag_i_lsst",
         column_names=refcols,
         mag_limits=def_maglims,
@@ -127,8 +127,8 @@ def test_KNearNeigh_justcol():
         zmin=0.0,
         zmax=3.0,
         nzbins=301,
-        trainfrac=0.75,
-        random_seed=87,
+        train_frac=0.75,
+        seed=87,
         ref_column_name="mag_i_lsst",
         column_names=refcols,
         mag_limits=def_maglims,
@@ -168,15 +168,15 @@ def test_catch_bad_bands():
 
 def test_randomForestClassifier():
     class_bands = ["r", "i", "z"]
-    bands = {"r": "mag_r_lsst", "i": "mag_i_lsst", "z": "mag_z_lsst"}
+    band_map = {"r": "mag_r_lsst", "i": "mag_i_lsst", "z": "mag_z_lsst"}
     bin_edges = [0, 0.2, 0.5]
 
     train_config_dict = dict(
         class_bands=class_bands,
-        bands=bands,
+        band_map=band_map,
         redshift_col="redshift",
         bin_edges=bin_edges,
-        random_seed=10,
+        seed=10,
         hdf5_groupname="photometry",
         model="model.tmp",
     )
@@ -201,15 +201,15 @@ def test_randomForestClassifier():
 
 def test_randomForestClassifier_id():
     class_bands = ["r", "i", "z"]
-    bands = {"r": "mag_r_lsst", "i": "mag_i_lsst", "z": "mag_z_lsst"}
+    band_map = {"r": "mag_r_lsst", "i": "mag_i_lsst", "z": "mag_z_lsst"}
     bin_edges = [0, 0.2, 0.5]
 
     train_config_dict = dict(
         class_bands=class_bands,
-        bands=bands,
+        band_map=band_map,
         redshift_col="redshift",
         bin_edges=bin_edges,
-        random_seed=10,
+        seed=10,
         hdf5_groupname="photometry",
         model="model.tmp",
     )


### PR DESCRIPTION
updated a couple params in code and tests (will do demo notebooks in a separate branch that I have going in rail repo)

bands -> band_map in random_forest
random_seed -> seed in random_forest
szname -> sz_name in nzdir
nsamples -> n_samples in nzdir

plus a couple of shared param updates
## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
